### PR TITLE
Add Repo Setup Formula

### DIFF
--- a/repos/.gitignore
+++ b/repos/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/repos/.gitignore
+++ b/repos/.gitignore
@@ -1,3 +1,13 @@
+# ------ Ipynb Ignore --------
+# https://github.com/jupyter/notebook/blob/main/.gitignore
+
+*.bundle.*
+lib/
+node_modules/
+*.egg-info/
+.ipynb_checkpoints
+*.tsbuildinfo
+
 # ------ Hydra Ignore --------
 outputs/
 

--- a/repos/.gitignore
+++ b/repos/.gitignore
@@ -1,3 +1,32 @@
+
+# ------ Vim Gitignore --------
+# https://github.com/github/gitignore/blob/main/Global/Vim.gitignore
+
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+#---------------------------------------------
+
+
+# ------ Autocreated Python Gitignore --------
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/repos/.gitignore
+++ b/repos/.gitignore
@@ -1,3 +1,5 @@
+# ------ Hydra Ignore --------
+outputs/
 
 # ------ Vim Gitignore --------
 # https://github.com/github/gitignore/blob/main/Global/Vim.gitignore

--- a/repos/README.md
+++ b/repos/README.md
@@ -1,0 +1,13 @@
+# Github Repo Quickstart
+
+By the end this will include:
+- Instructions on how to setup a new repo: rye, gitignore, pytest, etc
+- Sample starter README with instructions and links to copy
+- Sample .gitignore to copy
+- Sample `src/__init__.py` to copy
+- Sample `tests/starter_test.py` to copy and use to test pytest
+
+Also soon-to-be included here are guides for the common dev libraries that I use:
+- rye
+- hydra
+- wandb

--- a/repos/README.md
+++ b/repos/README.md
@@ -1,20 +1,118 @@
 # Github Repo Quickstart
 
-By the end this will include:
-- Instructions on how to setup a new repo: rye, gitignore, pytest, etc
-- Sample starter README with instructions and links to copy
-- Sample .gitignore to copy
-- Sample `src/__init__.py` to copy
-- Sample `tests/starter_test.py` to copy and use to test pytest
+Quickstart guide to setting up a new repo with rye.  See below for a list of files and guides included in this directory.
 
-Also soon-to-be included here are guides for the common dev libraries that I use:
-- rye
-- hydra
-- wandb
+**Deep Dives**
+- **Rye:** [rye_usage.md](https://github.com/drothermel/dr_setup/blob/repo_setup/repos/rye_usage.md)
+- **Hydra:** [hydra_usage.md](https://github.com/drothermel/dr_setup/blob/repo_setup/repos/hydra_usage.md)
+- **Wandb:** [wandb_usage.md](https://github.com/drothermel/dr_setup/blob/repo_setup/repos/wandb_usage.md)
 
-## Included File Templates
+**Template Files**
 
-`.gitignore`
-- Python base from github
-- Vim patterns also from github
-- IPynb patterns from jupyter
+- `.gitignore`
+  - Python base from github
+  - Vim patterns also from github
+  - IPynb patterns from jupyter
+- `STARTER_README.md`
+  - Link to this guide
+  - Basic commands for rye, wandb, hydra + links to deep dives
+- `__init__.py`
+  - Goes into `src/proj/__init__.py` to enable dummy pytest to work
+- `tests/`
+  - `__init__.py`
+  - Test file with a dummy test as an example for pytest
+  - Allows `rye test -v` to work immediately
+
+## Setup Instructions
+
+### Clone Repo, Setup Rye
+
+Clone the repo and setup a new branch for the req files that rye creates:
+```shell
+# Clone and make new branch
+git clone PROJ_URL
+cd PROJ; git checkout -b "setup_proj"; cd ..
+
+# Make sure you're outside of the repo dir before continuing
+```
+
+Initialize rye and ensure its setup correctly:
+```shell
+# Init rye, assume readme gets copied in later
+rye init --no-readme --name PROJ_NAME REPO_PATH
+cd REPO_PATH
+
+# rye sync creates the venv for the project and updates
+#  the req files, so sync and then commit them.
+rye sync
+git add .; git commit -m "init rye"
+
+# Rye manages python versions and everything pip, so choose
+#  the version of python you want and pin it.
+rye pin 3.12
+
+# Finally, test that its working as expected, expect the
+#  second command to print out the path to the rye venv
+rye sync
+python -c "import sys; print(sys.prefix)"
+
+# And see your new env
+rye show
+rye list
+```
+
+Add core dev and util requirements:
+```shell
+# Jupyterlab and Vim Bindings
+rye add --dev jupyterlab
+rye add --dev jupyterlab_vim
+
+# Pytest
+rye add --dev pytest
+
+# My Basic Utils
+rye add dr_util --git https://github.com/drothermel/dr_util.git
+
+# Finalize
+rye sync
+
+# Commit changes to your branch
+```
+
+
+### Add Template Files and Verify Setup
+
+Add template files from the top level dir in the repo:
+```shell
+# Set an env variable for your path to dr_setup repo
+export DRSETUP_PATH = "..."
+
+# Copy in the gitignore
+cp $DRSETUP_PATH/repos/.gitignore .
+
+# Copy in the README template
+cp $DRSETUP_PATH/repos/STARTER_README.md README.md
+
+# Copy in the __init__.py and tests dir
+cp $DRSETUP_PATH/repos/__init__.py ./src/PKG_NAME/__init__.py
+cp -r $DRSETUP_PATH/repos/tests .
+```
+
+Verify everything is setup correctly:
+```shell
+# Verify dr_util with interactive python
+>>> import dr_util.file_utils as fu
+>>> print(fu.fu_help())
+  ...expect output...
+>>> fu.load_file("./README.md", force_suffix="txt", verbose=True)
+  ...expect output...
+>>> exit()
+
+# Verify rye and pytest
+rye sync
+rye fmt
+rye lint --fix
+rye test -v
+```
+
+**Then you're good to go! Don't forget to merge your setup branch.**

--- a/repos/README.md
+++ b/repos/README.md
@@ -11,3 +11,10 @@ Also soon-to-be included here are guides for the common dev libraries that I use
 - rye
 - hydra
 - wandb
+
+## Included File Templates
+
+`.gitignore`
+- Python base from github
+- Vim patterns also from github
+- IPynb patterns from jupyter

--- a/repos/STARTER_README.md
+++ b/repos/STARTER_README.md
@@ -1,0 +1,65 @@
+## Readme Template
+
+A starter readme with basic info for interacting with a new rye repo.
+
+Assumes you followed setup instructions from [dr_setup/repos](https://github.com/drothermel/dr_setup/blob/repo_setup/repos/README.md) which will provide:
+- `.gitignore` with vim, python, jupyter support
+- `rye` setup process
+- `src/package/__init__.py` and `tests/...` dir to enable `rye test`
+
+## Using Rye
+
+Full deep dive: [dr_setup/repos/rye_usage.md](https://github.com/drothermel/dr_setup/blob/repo_setup/repos/rye_usage.md)
+
+Ideally rye has already been setup:
+```shell
+rye init --no-readme --name PROJ_NAME REPO_PATH
+rye pin 3.12
+rye sync
+rye show
+rye list # jupyterlab, jupyterlab_vim, pytest, dr_util
+```
+
+Basic Usage:
+```
+rye add PACKAGE (opt: --dev) (opt: --git URL)
+rye remove PACKAGE (opt: --dev)
+rye fmt
+rye lint --fix
+rye test -v
+rye run TOOL_NAME
+```
+
+## Using hydra + wandb
+
+- Hydra deep dive: [dr_setup/repos/hydra_usage.md](https://github.com/drothermel/dr_setup/blob/repo_setup/repos/hydra_usage.md)
+- Wandb deep dive: [dr_setup/repos/wandb_usage.md
+](https://github.com/drothermel/dr_setup/blob/repo_setup/repos/wandb_usage.md)
+
+Install both:
+```shell
+rye add wandb
+rye add hydra-core==1.3
+```
+
+Use both in a script:
+```python
+import wandb
+import hydra
+from omegaconf import DictConfig, OmegaConf
+
+@hydra.main(version_base=None, config_path="conf", config_name="qmp_cfg")
+def run(cfg: DictConfig):
+  logging.info(">> Input config yaml:")
+  logging.info("\n" + str(OmegaConf.to_yaml(cfg)))
+	
+  cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+  wandb.init(
+    project='name',
+    config=cfg_dict,
+  )
+  wandb.log({"data": 100})
+
+if __name__ == "__main__":
+  run()
+```

--- a/repos/__init__.py
+++ b/repos/__init__.py
@@ -1,0 +1,4 @@
+def one_plus_one(x, y) -> int:
+    assert x == 1 and y == 1, "Inputs must be 1"
+    two = x + y
+    return two

--- a/repos/hydra_usage.md
+++ b/repos/hydra_usage.md
@@ -1,0 +1,53 @@
+# Hydra Usage Notes
+
+The current version is 1.3, which works with python 3.6-3.11.
+
+Installation:
+```shell
+rye add hydra-core==1.3
+```
+
+## Usage Example
+
+Top Level Config
+```yaml
+# conf/qmp_passages.yaml
+
+defaults:
+- gold_split: dev
+- _self_
+
+trial: 0
+dataset_dir: /scratch/ddr8143/multiqa/downloads/data/qampari/
+remove_passages_without_answers: True
+wandb: True
+wandb_project: qmp_gt_annotations
+processes: 48
+```
+
+Nested Config
+```yaml
+# conf/gold_split/dev.yaml
+
+name: dev
+dataset_filename: dev_data.jsonl
+proof_filename: dev_proof_data.pkl
+proof_passage_dirname: dev_proof_to_passage
+gold_filename: dev_data_gold.jsonl
+```
+
+Usage in Python Script
+```python
+import hydra
+from omegaconf import DictConfig, OmegaConf
+
+@hydra.main(version_base=None, config_path="conf", config_name="qmp_passages")
+def run(cfg: DictConfig):
+		logging.info(">> Input config yaml:")
+		logging.info("\n" + str(OmegaConf.to_yaml(cfg)))
+	
+		config_dict = OmegaConf.to_container(cfg, resolve=True)
+
+if __name__ == "__main__":
+		run()
+```

--- a/repos/rye_usage.md
+++ b/repos/rye_usage.md
@@ -1,0 +1,98 @@
+# How to Install and Use Rye
+
+Official Docs: [rye.astral.sh](https://rye.astral.sh/)
+
+## Using Rye
+```shell
+# Show state of env
+rye show
+
+# Show deps
+rye list
+
+# Add a dependency
+rye add <pip_package_name> (optional: --dev)
+
+# Remove a dependency
+rye remove <pip_package_name> (optional: --dev)
+
+# Refresh State (mainly happens automatically
+rye sync
+
+# Run black
+rye fmt
+
+# Run lint (and fix easy things)
+rye lint --fix
+
+# Run tests
+rye test -v -s
+
+# Run program
+rye run <tool_name>
+
+# Pin a version of python
+rye pin 3.12
+```
+
+And learn to run scripts by seeing the bottom of [this page](https://rye.astral.sh/guide/basics/#inspecting-the-project).
+
+## Install Rye
+
+Follow instructions from the [rye project](https://rye.astral.sh/):
+```shell
+# Install rye
+curl -sSf https://rye.astral.sh/get | bash
+
+# Add the following to your .bashrc equivalent (after conda path updates!)
+source "$HOME/.rye/env"
+
+# Potentially add shell completion, etc by following this guide:
+#  https://rye.astral.sh/guide/installation/#shell-completion
+```
+
+## Setup Rye for Repo
+
+Clone the project and initialize rye in a setup branch:
+```shell
+# Clone and make new branch
+git clone PROJ_URL
+cd PROJ; git checkout -b "setup_proj"; cd ..
+
+# Init rye, assume readme gets copied in later
+rye init --no-readme --name PROJ_NAME REPO_PATH
+cd REPO_PATH
+
+# rye sync creates the venv for the project and updates
+#  the req files, so sync and then commit them.
+rye sync
+git add .; git commit -m "init rye"
+
+# Rye manages python versions and everything pip, so choose
+#  the version of python you want and pin it.
+rye pin 3.12
+
+# Finally, test that its working as expected, expect the
+#  second command to print out the path to the rye venv
+rye sync
+python -c "import sys; print(sys.prefix)"
+```
+
+Then install main dev and util requirements.
+```shell
+
+# Jupyterlab and Vim Bindings
+rye add --dev jupyterlab
+rye add --dev jupyterlab_vim
+
+# Pytest
+rye add --dev pytest
+
+# My Basic Utils
+rye add dr_util --git https://github.com/drothermel/dr_util.git
+
+# Finalize
+rye sync
+
+# Commit changes to your branch
+```

--- a/repos/rye_usage.md
+++ b/repos/rye_usage.md
@@ -1,41 +1,62 @@
 # How to Install and Use Rye
 
-Official Docs: [rye.astral.sh](https://rye.astral.sh/)
+**Resources**
+- Official Docs: [rye.astral.sh](https://rye.astral.sh/)
+- Intro Video: [youtube](https://rye.astral.sh/guide/)
+- Overview of Env Management + Packaging Tools (for context): [by Anna-Lena Popkes](https://alpopkes.com/posts/python/packaging_tools/)
 
 ## Using Rye
+
+Refresh State (mainly happens automatically)
+```shell
+rye sync
+```
+
+Inspect the state of the env
 ```shell
 # Show state of env
 rye show
 
 # Show deps
 rye list
+```
+
+Manage dependencies
+```shell
+# Pin a version of python
+rye pin 3.12
 
 # Add a dependency
 rye add <pip_package_name> (optional: --dev)
 
 # Remove a dependency
 rye remove <pip_package_name> (optional: --dev)
+```
 
-# Refresh State (mainly happens automatically
-rye sync
-
+Format, lint, test
+```shell
 # Run black
-rye fmt
+rye fmt (optional: file path)
 
 # Run lint (and fix easy things)
 rye lint --fix
 
 # Run tests
-rye test -v -s
+rye test -v
+    -s: No capture, disable stdout/stderr capture so it prints out
+    -a: Test all packages in workspace
+    -- -k 'single_test_name[single_param]': just run one test
+```
 
+Running Tools & Scripts
+```shell
 # Run program
 rye run <tool_name>
 
-# Pin a version of python
-rye pin 3.12
-```
+# Learn to run scripts at bottom of:
+# https://rye.astral.sh/guide/basics/#inspecting-the-project
 
-And learn to run scripts by seeing the bottom of [this page](https://rye.astral.sh/guide/basics/#inspecting-the-project).
+```
 
 ## Install Rye
 
@@ -49,6 +70,12 @@ source "$HOME/.rye/env"
 
 # Potentially add shell completion, etc by following this guide:
 #  https://rye.astral.sh/guide/installation/#shell-completion
+```
+
+### Zsh Specific
+```
+mkdir $ZSH_CUSTOM/plugins/rye
+rye self completion -s zsh > $ZSH_CUSTOM/plugins/rye/_rye
 ```
 
 ## Setup Rye for Repo
@@ -76,6 +103,10 @@ rye pin 3.12
 #  second command to print out the path to the rye venv
 rye sync
 python -c "import sys; print(sys.prefix)"
+
+# And see your new env
+rye show
+rye list
 ```
 
 Then install main dev and util requirements.

--- a/repos/tests/test_template.py
+++ b/repos/tests/test_template.py
@@ -1,0 +1,13 @@
+import pytest
+import bytom as bt
+
+# Dummy test
+def test_one_plus_one():
+    two = bt.one_plus_one(1, 1)
+    assert two == 2
+
+    # Note "match" is optional
+    with pytest.raises(AssertionError, match="Inputs must be 1"):
+        fail = bt.one_plus_one(3, 3)
+
+    

--- a/repos/tests/test_template.py
+++ b/repos/tests/test_template.py
@@ -1,6 +1,7 @@
 import pytest
 import bytom as bt
 
+
 # Dummy test
 def test_one_plus_one():
     two = bt.one_plus_one(1, 1)
@@ -8,6 +9,4 @@ def test_one_plus_one():
 
     # Note "match" is optional
     with pytest.raises(AssertionError, match="Inputs must be 1"):
-        fail = bt.one_plus_one(3, 3)
-
-    
+        bt.one_plus_one(3, 3)

--- a/repos/wandb_usage.md
+++ b/repos/wandb_usage.md
@@ -1,0 +1,165 @@
+# Using Wandb
+
+**TODO:** Get link to docs.
+
+**Additional Resources**
+-- Note these may or may not actually work, it seems to be very poorly maintained…
+- Data visualization guide: ([here](https://docs.wandb.ai/guides/data-vis))
+- Tables tutorial: ([here](https://wandb.ai/stacey/nlg/reports/Visualize-Text-Data-Predictions--Vmlldzo1NzcwNzY?_gl=1*g9vscn*_ga*NTUyNDM3NDQ0LjE2OTAyMjQ1Mjc.*_ga_JH1SJHJQXJ*MTY5MDIyNDUyNi4xLjEuMTY5MDIyNTEwOC4xNi4wLjA.)) ([quickstart](https://docs.wandb.ai/guides/data-vis/tables-quickstart))
+- Artifacts ([here](https://docs.wandb.ai/guides/artifacts)) ([example here](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-artifacts/Pipeline_Versioning_with_W%26B_Artifacts.ipynb))
+
+
+## Install and Setup
+
+```shell
+# Install the package with rye
+rye add wandb
+
+# On a new machine, login
+wandb login
+```
+
+## Basic Usage
+```python
+import wandb
+
+# TODO: Get cfg_dict example
+wandb.init(
+  project='name',
+  config=cfg_dict,
+)
+
+wandb.log({"data": 100})
+```
+
+### Write Locations
+```shell
+# Right now only 1.4G despite never clearing it, so probably don't
+# need to worry about this
+/scratch/ddr8143/python_cache/.cache/wandb
+
+# You can clean it with, where the final value is to leave
+# anything smaller than 0GB (nothing)
+# note that it clears the data but leaves the artifact directories,
+# so to handle inode issues you might want to manually clear the
+# the cache occasionally
+wandb artifact cache cleanup 0GB
+
+# The main logging is done to wandb.run.dir
+# you can clean this after wandb.finish() is called but if you remove
+# anything before you run will fail.
+```
+
+## Logging Examples
+
+### Config Logging
+It’s possible to programatically get the history and data from a run in python using the run_id.
+
+```python
+import wandb
+import omegaconf
+
+# You can do this outside of the run creation:
+wandb.config = omegaconf.OmegaConf.to_container(
+    cfg, resolve=True, throw_on_missing=True
+)
+
+# Or inside of the run creation:
+run = wandb.init(
+    name=run_name,
+    project=cfg.wandb_project,
+    config=run_cfg, # here
+)
+```
+
+### Metric Logging
+
+```python
+import wandb
+import matplotlib.pyplot as plt
+
+# Create a table to make a custom chart (including composite histograms, here)
+my_custom_data = [[x1, y1, z1], [x2, y2, z2]]
+wandb.log({"custom_data_table": wandb.Table(data=my_custom_data,
+                                columns = ["x", "y", "z"])})
+
+# I think this autoconverts my data to a histogram of the data
+wandb.log({"losses": wandb.Histogram(losses)})
+
+# Log the histogram directly (here)
+data = [[s] for s in scores]
+table = wandb.Table(data=data, columns=["scores"])
+wandb.log({'my_histogram': wandb.plot.histogram(table, "scores",
+ 	  title="Prediction Score Distribution")})
+
+# PR curves (here)
+wandb.log({"pr": wandb.plot.pr_curve(ground_truth, predictions)})
+
+# Log a matplotlib or plotlyplot directly (here)
+plt.plot([1, 2, 3, 4])
+plt.ylabel("some interesting numbers")
+wandb.log({"chart": plt})
+
+# Log a table (here)
+my_table = wandb.Table(
+    columns=["a", "b"], 
+    data=[["a1", "b1"], ["a2", "b2"]]
+    )
+run.log({"Table Name": my_table})
+```
+
+### Artifact Logging
+```python
+import wandb
+
+# Current types: input_data_raw, input_data, dataset, training_data
+#                scored_data, model, 
+
+# Input artifacts (hosted locally)
+in_artifact = wandb.Artifact(
+    f'qmp_proof2chunk_raw__{split_name}', type='input_data_raw',
+    description='Dir with chunk_*_*.json of qmp questions with proofs matched to context passages.',
+    metadata={
+        'script': 'set_cp.scripts.qmp_gold_chunk_match',
+        'cfg': OmegaConf.to_container(cfg.gold_chunk_match, resolve=True),
+    },
+)
+in_artifact.add_reference(f'file://{output_dir}')
+run.use_artifact(in_artifact) ## IMPORTANT: USE_artifact
+
+# Output artifacts (hosted locally)
+out_artifact = wandb.Artifact(
+    f'qmp_gt_evidence__{split_name}', type='input_data',
+    description='Jsonl file with evidence chunks matching annotated proofs for qmp questions',
+    metadata={
+        'script': 'set_cp.scripts.qmp_gold_chunk_agg',
+        'cfg': OmegaConf.to_container(cfg, resolve=True),
+    },
+)
+out_artifact.add_reference(f'file://{output_file}')
+run.log_artifact(out_artifact) ## IMPORTANT: LOG_artifact
+```
+
+## Reports
+
+**Report Examples:**
+- Entity Linking (with ELQ) v0: [here](https://drive.google.com/file/d/13NRit-L9KqJIEdkuz-iVsyk99zvUHa8m/view?usp=drive_link)
+- Qent2sid Graphs v0: [here](https://drive.google.com/file/d/1nVCNigN4mdDpUUiGzLHWnip9DTp3UBX_/view?usp=drive_link)
+- Scatter plot by time: [here](https://drive.google.com/file/d/19l6-5G6BgVyPAhav3fNGCPuMvb_ADq57/view?usp=drive_link)
+- PR line plot: [here](https://drive.google.com/file/d/1h-dWxi1vVqdRokGPBNqFv2x7NdHyyh1T/view?usp=drive_link)
+- Comparative bar plot: [here](https://drive.google.com/file/d/16-ekToKZYEPj8Zu5LjVx60kSYov9K5GF/view?usp=drive_link)
+
+**Visualizations**
+- Comparative histograms: (see [GT Annotations](https://wandb.ai/danielle-rothermel/qmp_gt_annotations/reports/GT-Annotations--Vmlldzo1MzAxODA4) report for example)
+    - Have to be done quite manually, but possible
+- Charts are created with the incredibly flexible Vega/Vegalite language
+- Histograms just don’t work, but you can create your own if you spend long enough with Vega
+- You have to choose Vega or Vegalite (you can’t mix syntax) but either works.
+    - It feels easier to do complex things with Vega but the number of examples is much smaller.
+- What I currently have:
+    - A layered histogram with vegalite that will take two runs from wandb and log them together.
+    - A composite histogram that will take two keys in the same run.
+ 
+**Tables**
+- For now the best I can do is stack tables from different runs on top of each other —> must log a metrics table for each run (see GT Annotations report)
+


### PR DESCRIPTION
Provide a formula for quickly setting up a new repo with rye.

Currently Includes:
- Stencil setup guide in the form of a readme that has todos to check off before landing this!
- `.gitignore` for python, vim, jupyter, hydra
- Starter files for `src/` and `tests/` to enable `rye test` to work
- Deep dive readme for rye: `repos/rye_usage.md`
- Deep dive readme for wandb:  `repos/wandb_usage.md`
- Deep dive readme for hydra: `repos/hydra_usage.md`
- `STARTER_README.md` as example to copy with basic instructions
- Quickstart instructions in `README.md`

There are definitely things to improve, but this works (as tested in the `by_tomorrow` repo).